### PR TITLE
No double validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,36 @@
+# Version 2.4.0 - January 15, 2021
+
+- `#call`, `#call_and_raise`, and `#call!` now accept an optional keyword parameter called `validate`. This will
+  skip validations if passed `false`. (`true` is the default value.)
+- `#call!` now takes advantage of the `validate:` parameter internally to avoid running validations twice.
+
 # Version 2.3.0 - April 3, 2020
 
-* `#call!` now raises the underlying exception if the service threw an exception,
+- `#call!` now raises the underlying exception if the service threw an exception,
   rather than hiding it inside a `CivilService::ServiceFailure`.
 
 # Version 2.2.1 - October 4, 2019
 
-* `CivilService::MultiResultService::MultiResult#exception` now checks the underlying exception on
+- `CivilService::MultiResultService::MultiResult#exception` now checks the underlying exception on
   the root result object, in case the service threw an exception.
 
 # Version 2.2.0 - September 26, 2019
 
-* Services now have a new `#call_and_raise` method, which will return a result object on failure
+- Services now have a new `#call_and_raise` method, which will return a result object on failure
   but will raise exceptions that are thrown inside the service call (effectively, the behavior of
   `#call` in CivilService 1.0.0).
-* Added a new mixin called `CivilService::MultiResultService`, which allows creating services whose
+- Added a new mixin called `CivilService::MultiResultService`, which allows creating services whose
   results are composed of multiple results that are aggregated together.
 
 # Version 2.1.0 - September 25, 2019
 
-* `CivilService::Result#errors` now always returns an Errors object even if it hasn't been
+- `CivilService::Result#errors` now always returns an Errors object even if it hasn't been
   explicitly set.
 
 # Version 2.0.0 - June 26, 2019
 
-* BREAKING CHANGE: The behavior of `CivilService::Service#call` has changed when exceptions are
-  raised inside the service.  The `call` method will now catch the exception and return a failing
+- BREAKING CHANGE: The behavior of `CivilService::Service#call` has changed when exceptions are
+  raised inside the service. The `call` method will now catch the exception and return a failing
   result object, with the exception message as an error on `:base`.
 
   The behavior of `call!` has not changed: a failing result will be raised as a
@@ -35,8 +41,9 @@
   will (almost) never raise an exception, whereas `call!` can raise an exception.
 
   The exception to this rule (pun intended, always intend your puns) is that `call` will not catch
-  exceptions that don't inherit from `StandardError`, such as `SystemExit`.  See
+  exceptions that don't inherit from `StandardError`, such as `SystemExit`. See
   [Honeybadger's explanation](https://www.honeybadger.io/blog/a-beginner-s-guide-to-exceptions-in-ruby/)
   of why this is a good idea.
-* `CivilService::Result` now has an additional attribute called `exception`, which can be used to
+
+- `CivilService::Result` now has an additional attribute called `exception`, which can be used to
   retrieve an exception thrown inside a `call` method.

--- a/lib/civil_service/service.rb
+++ b/lib/civil_service/service.rb
@@ -12,8 +12,8 @@ class CivilService::Service
     end
   end
 
-  def call
-    unless self.class.validate_manually
+  def call(validate: true)
+    if validate && !self.class.validate_manually
       return failure(errors) unless valid?
     end
 
@@ -25,8 +25,8 @@ class CivilService::Service
     end
   end
 
-  def call_and_raise
-    result = call
+  def call_and_raise(validate: true)
+    result = call(validate: validate)
     if result.exception
       raise result.exception, result.exception.message, result.exception.backtrace
     end
@@ -34,12 +34,12 @@ class CivilService::Service
     result
   end
 
-  def call!
-    unless self.class.validate_manually
+  def call!(validate: true)
+    if validate && !self.class.validate_manually
       raise CivilService::ServiceFailure.new(self, failure(errors)) unless valid?
     end
 
-    result = call_and_raise
+    result = call_and_raise(validate: false) # we already just did the validation step if needed
     raise CivilService::ServiceFailure.new(self, result) if result.failure?
     result
   end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -114,6 +114,21 @@ class ServiceTest < Minitest::Spec
         MyService.validate_manually = false
       end
     end
+
+    it 'skips validations if #call(validate: false) is called' do
+      result = service.call(validate: false)
+      assert result.success?
+    end
+
+    it 'skips validations if #call_and_raise(validate: false) is called' do
+      result = service.call_and_raise(validate: false)
+      assert result.success?
+    end
+
+    it 'skips validations if #call!(validate: false) is called' do
+      result = service.call!(validate: false)
+      assert result.success?
+    end
   end
 
   describe 'custom result classes' do


### PR DESCRIPTION
This PR provides a way to avoid validations being called twice:

- `#call`, `#call_and_raise`, and `#call!` now accept an optional keyword parameter called `validate`. This will
  skip validations if passed `false`. (`true` is the default value.)
- `#call!` now takes advantage of the `validate:` parameter internally to avoid running validations twice.