### PR TITLE
fix OR operator

### DIFF
--- a/lib/civil_service/service.rb
+++ b/lib/civil_service/service.rb
@@ -8,7 +8,7 @@ class CivilService::Service
     attr_writer :result_class
 
     def result_class
-      @result_class || CivilService::Result
+      @result_class ||= CivilService::Result
     end
   end
 
@@ -45,7 +45,7 @@ class CivilService::Service
   end
 
   def logger
-    @logger || Rails.logger
+    @logger ||= Rails.logger
   end
 
   private


### PR DESCRIPTION
Since `nil` is falsey, I used `||=` to make the OR operator more meaningful. If `@result_ class` is already initialized it will keep the same value, else if it’s nil it will be initialized with the value of `CivilService::Result`.